### PR TITLE
Fix null buffer lengths.

### DIFF
--- a/lib/messages/commands/filteradd.js
+++ b/lib/messages/commands/filteradd.js
@@ -24,7 +24,7 @@ function FilteraddMessage(arg, options) {
     _.isUndefined(arg) || Buffer.isBuffer(arg),
     'First argument is expected to be a Buffer or undefined'
   );
-  this.data = arg || Buffer.alloc(1);
+  this.data = arg || Buffer.alloc(0);
 }
 inherits(FilteraddMessage, Message);
 

--- a/lib/messages/commands/filterclear.js
+++ b/lib/messages/commands/filterclear.js
@@ -19,7 +19,7 @@ inherits(FilterclearMessage, Message);
 FilterclearMessage.prototype.setPayload = function() {};
 
 FilterclearMessage.prototype.getPayload = function() {
-  return Buffer.alloc(1);
+  return Buffer.alloc(0);
 };
 
 module.exports = FilterclearMessage;

--- a/lib/messages/commands/filterload.js
+++ b/lib/messages/commands/filterload.js
@@ -34,7 +34,7 @@ FilterloadMessage.prototype.getPayload = function() {
   if(this.filter) {
     return this.filter.toBuffer();
   } else {
-    return Buffer.alloc(1);
+    return Buffer.alloc(0);
   }
 };
 

--- a/lib/messages/commands/getaddr.js
+++ b/lib/messages/commands/getaddr.js
@@ -20,7 +20,7 @@ inherits(GetaddrMessage, Message);
 GetaddrMessage.prototype.setPayload = function() {};
 
 GetaddrMessage.prototype.getPayload = function() {
-  return Buffer.alloc(1);
+  return Buffer.alloc(32, 0);
 };
 
 module.exports = GetaddrMessage;

--- a/lib/messages/commands/mempool.js
+++ b/lib/messages/commands/mempool.js
@@ -22,7 +22,7 @@ inherits(MempoolMessage, Message);
 MempoolMessage.prototype.setPayload = function() {};
 
 MempoolMessage.prototype.getPayload = function() {
-  return Buffer.alloc(1);
+  return Buffer.alloc(0);
 };
 
 module.exports = MempoolMessage;

--- a/lib/messages/commands/merkleblock.js
+++ b/lib/messages/commands/merkleblock.js
@@ -34,7 +34,7 @@ MerkleblockMessage.prototype.setPayload = function(payload) {
 };
 
 MerkleblockMessage.prototype.getPayload = function() {
-  return this.merkleBlock ? this.merkleBlock.toBuffer() : Buffer.alloc(1);
+  return this.merkleBlock ? this.merkleBlock.toBuffer() : Buffer.alloc(0);
 };
 
 module.exports = MerkleblockMessage;

--- a/lib/messages/commands/verack.js
+++ b/lib/messages/commands/verack.js
@@ -19,7 +19,7 @@ inherits(VerackMessage, Message);
 VerackMessage.prototype.setPayload = function() {};
 
 VerackMessage.prototype.getPayload = function() {
-  return Buffer.alloc(1);
+  return Buffer.alloc(0);
 };
 
 module.exports = VerackMessage;

--- a/lib/messages/utils.js
+++ b/lib/messages/utils.js
@@ -109,7 +109,7 @@ module.exports = utils = {
       stop = reverse(Buffer.from(stop, 'hex'));
     }
     if (!stop) {
-      stop = Buffer.alloc(1);
+      stop = Buffer.alloc(32, 0);
     }
     obj.starts = starts;
     obj.stop = stop;


### PR DESCRIPTION
These used to reference constants from bitcore.util.buffer .  They've since
been changed to allocate newly each, to move from bitcore to bsv, but the
correct lengths weren't preserved.  I tried to copy them all over from bitcore.
I often make copy errors, but it should be at least improved.

Fixes #16 