### PR TITLE
Remove check for version message finish

### DIFF
--- a/lib/messages/commands/version.js
+++ b/lib/messages/commands/version.js
@@ -69,7 +69,6 @@ VersionMessage.prototype.setPayload = function(payload) {
   } else {
     this.relay = !!parser.readUInt8();
   }
-  utils.checkFinished(parser);
 };
 
 VersionMessage.prototype.getPayload = function() {


### PR DESCRIPTION
Starting with bitcoin-sv 1.0.7, version messages have an additional
field containing the association id. Removing the check that enforces
version message length allows the library to remain compatible with new
nodes without implementing the multiple streams feature.